### PR TITLE
Fix CSS and Javascript paths in layout file

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,9 +13,9 @@
         <meta name="viewport" content="width=device-width,initial-scale=1">
 
         <link rel="stylesheet" href="//cloud.typography.com/7855472/767342/css/fonts.css">
-        <link rel="stylesheet" href="/css/docs.css">
+        <link rel="stylesheet" href="css/docs.css">
 
-        <script src="/js/modernizr.js"></script>
+        <script src="js/modernizr.js"></script>
         <script>
             var _gaq=_gaq||[];_gaq.push(["_setAccount","UA-3625251-12"]);_gaq.push(["_trackPageview"]);(function(){var a=document.createElement("script");a.type="text/javascript";a.async=!0;a.src=("https:"==document.location.protocol?"https://ssl":"http://www")+".google-analytics.com/ga.js";var b=document.getElementsByTagName("script")[0];b.parentNode.insertBefore(a,b)})();
             var _gauges=_gauges||[];(function(){var a=document.createElement("script");a.type="text/javascript";a.async=!0;a.id="gauges-tracker";a.setAttribute("data-site-id","4faf1bdff5a1f501f8000047");a.src="//secure.gaug.es/track.js";var b=document.getElementsByTagName("script")[0];b.parentNode.insertBefore(a,b)})();


### PR DESCRIPTION
`/css/docs.css` points to `http://dryan.github.io/css/docs.css`, which does not exist. Stripping the leading slash (→ `css/docs.css`) fixes it (→ `http://dryan.github.io/css-smart-grid/css/docs.css`).

Same for `modernizr.js`.
