### PR TITLE
Update append syntax for column-set mixin

### DIFF
--- a/sass/smart-grid-columns.scss
+++ b/sass/smart-grid-columns.scss
@@ -29,7 +29,7 @@
         @each $i in $column-list {
             $selectors: ();
             @for $j from 2 to length($i) + 1 {
-                $selectors: $selectors, unquote("&.#{nth($i, $j)}");
+                $selectors: append($selectors, unquote("&.#{nth($i, $j)}", comma);
             }
             #{$selectors} {
                 @include columns(nth($i, 1));
@@ -38,7 +38,7 @@
         @each $i in $offset-list {
             $selectors: ();
             @for $j from 2 to length($i) + 1 {
-                $selectors: $selectors, unquote("&.offset-#{nth($i, $j)}");
+                $selectors: append($selectors, unquote("&.offset-#{nth($i, $j)}");
             }
             #{$selectors} {
                 @include offset(nth($i, 1));

--- a/sass/smart-grid-columns.scss
+++ b/sass/smart-grid-columns.scss
@@ -29,7 +29,7 @@
         @each $i in $column-list {
             $selectors: ();
             @for $j from 2 to length($i) + 1 {
-                $selectors: append($selectors, unquote("&.#{nth($i, $j)}", comma);
+                $selectors: append($selectors, unquote("&.#{nth($i, $j)}"), comma);
             }
             #{$selectors} {
                 @include columns(nth($i, 1));
@@ -38,7 +38,7 @@
         @each $i in $offset-list {
             $selectors: ();
             @for $j from 2 to length($i) + 1 {
-                $selectors: append($selectors, unquote("&.offset-#{nth($i, $j)}");
+                $selectors: append($selectors, unquote("&.offset-#{nth($i, $j)}"), comma);
             }
             #{$selectors} {
                 @include offset(nth($i, 1));


### PR DESCRIPTION
I discovered that the syntax of appending to a list without explicitly setting a "comma" was breaking in 

```
"node-sass": "3.0.0-beta.7",
"libsass": "3.2.0-beta.6"
```

Reference Libsass issue here https://github.com/sass/libsass/issues/1122#issuecomment-95267367